### PR TITLE
Check KafkaErrors are marked fatal before giving up

### DIFF
--- a/sherlock_wrapper/wrapper.py
+++ b/sherlock_wrapper/wrapper.py
@@ -82,7 +82,11 @@ def consume(conf, log, alerts, consumer):
         msg = c.poll(10)
         if msg is not None and msg.error():
             log.error("Kafka Error:"+str(msg.error()))
-        raise Exception("Unrecoverable Kafka error.")
+        # if the error is fatal then give up
+        if e.args[0].fatal():
+            raise Exception("Unrecoverable Kafka error.")
+        else:
+            n_error += 1
     finally:
         pass
     return n


### PR DESCRIPTION
Change wrapper consumer loop to check whether a KafkaError is marked as fatal before giving up, instead of giving up on any otherwise unhandled error. This *might* solve #86 (but can't really test other than on a live stream), but is probably worth doing anyway.