### PR TITLE
remove db name fixes #145

### DIFF
--- a/utility/schema/annotations.sql
+++ b/utility/schema/annotations.sql
@@ -1,4 +1,3 @@
-USE ztf;
 CREATE TABLE IF NOT EXISTS annotations(
 `annotationID` int NOT NULL AUTO_INCREMENT,
 `objectId` varchar(16) NOT NULL,

--- a/utility/schema/area_hits.sql
+++ b/utility/schema/area_hits.sql
@@ -1,4 +1,3 @@
-USE ztf;
 CREATE TABLE IF NOT EXISTS area_hits(
 `objectId` varchar(16) CHARACTER SET utf8 COLLATE utf8_unicode_ci,
 `ar_id` int,

--- a/utility/schema/convert.py
+++ b/utility/schema/convert.py
@@ -39,7 +39,7 @@ def create_table(schema):
         lines.append(s)
     #    if 'doc'     in f and f['doc']:     s += ', ' + f['doc']
     
-    sql = 'USE ztf;\nCREATE TABLE IF NOT EXISTS ' + schema['name'] + '(\n'
+    sql = 'CREATE TABLE IF NOT EXISTS ' + schema['name'] + '(\n'
     sql += ',\n'.join(lines)
 
     if 'indexes' in schema:

--- a/utility/schema/crossmatch_tns.sql
+++ b/utility/schema/crossmatch_tns.sql
@@ -1,4 +1,3 @@
-USE ztf;
 CREATE TABLE IF NOT EXISTS crossmatch_tns(
 `ra` double,
 `decl` double,

--- a/utility/schema/sherlock_classifications.sql
+++ b/utility/schema/sherlock_classifications.sql
@@ -1,4 +1,3 @@
-USE ztf;
 CREATE TABLE IF NOT EXISTS sherlock_classifications(
 `objectId` varchar(16) CHARACTER SET utf8 COLLATE utf8_unicode_ci,
 `classification` varchar(16),

--- a/utility/schema/watchlist_hits.sql
+++ b/utility/schema/watchlist_hits.sql
@@ -1,4 +1,3 @@
-USE ztf;
 CREATE TABLE IF NOT EXISTS watchlist_hits(
 `objectId` varchar(16) CHARACTER SET utf8 COLLATE utf8_unicode_ci,
 `wl_id` int,


### PR DESCRIPTION
Removes the explicit database name from the start of the SQL schema files - see #145 for rationale.